### PR TITLE
Add comments functionality and integrate comment count in feed

### DIFF
--- a/css/components/post-card.css
+++ b/css/components/post-card.css
@@ -129,3 +129,4 @@
   opacity: 0.7;
   cursor: wait;
 }
+

--- a/js/api/comments.js
+++ b/js/api/comments.js
@@ -1,0 +1,14 @@
+import { apiRequest } from "./requests.js";
+
+export function createComment(postId, body) {
+  if (!postId) throw new Error("Post ID is required");
+
+  const trimmedBody = body?.trim();
+
+  if (!trimmedBody) throw new Error("Comment body is required");
+
+  return apiRequest(`/social/posts/${postId}/comment`, {
+    method: "POST",
+    body: JSON.stringify({ body: trimmedBody }),
+  });
+}

--- a/js/api/posts.js
+++ b/js/api/posts.js
@@ -6,6 +6,7 @@ export function getPosts({ limit = 12, sort = "created", sortOrder = "desc" } = 
     sort,
     sortOrder,
     _author: "true",
+    _count: "true",
   });
 
   return apiRequest(`/social/posts?${params.toString()}`);
@@ -14,7 +15,7 @@ export function getPosts({ limit = 12, sort = "created", sortOrder = "desc" } = 
 export function getPostById(id) {
   if (!id) throw new Error("Post ID is required");
 
-  return apiRequest(`/social/posts/${id}?_author=true`);
+  return apiRequest(`/social/posts/${id}?_author=true&_comments=true`);
 }
 
 export function createPost(data) {

--- a/js/components/comments.js
+++ b/js/components/comments.js
@@ -1,0 +1,42 @@
+export function renderComments(comments = []) {
+  return `
+    <section class="comments">
+      <h2 class="comments__title">Comments (${comments.length})</h2>
+
+      <form class="comments__form" id="comment-form">
+        <label class="comments__label" for="comment-body">Add a comment</label>
+        <textarea
+          id="comment-body"
+          name="comment-body"
+          class="comments__textarea"
+          rows="4"
+          placeholder="Write your comment..."
+          required
+        ></textarea>
+        <button type="submit" class="comments__submit">Post comment</button>
+        <p class="comments__message" id="comment-message" aria-live="polite"></p>
+      </form>
+
+      ${
+        comments.length
+          ? `
+            <ul class="comments__list">
+              ${comments
+                .map(
+                  (comment) => `
+                    <li class="comments__item">
+                      <p class="comments__meta">
+                        <strong>${comment.author?.name || "Unknown user"}</strong>
+                      </p>
+                      <p class="comments__body">${comment.body || ""}</p>
+                    </li>
+                  `
+                )
+                .join("")}
+            </ul>
+          `
+          : `<p class="comments__empty">No comments yet. Be the first to comment!</p>`
+      }
+    </section>
+  `;
+}

--- a/js/components/postCard.js
+++ b/js/components/postCard.js
@@ -25,48 +25,56 @@ export function createPostCard(post, options = {}) {
   const author = post.author?.name || "Unknown author";
   const media = post.media?.url || "";
   const alt = post.media?.alt || post.title || "Post image";
+  const commentCount = post._count?.comments ?? 0;
   const isOwner =
   currentUserName &&
   author &&
   currentUserName.trim().toLowerCase() === author.trim().toLowerCase();
  
-  return `
-    <article class="post-card">
-      <a
-       class="post-card__media-link" 
-       href="${ROUTES.post(post.id)}" 
-       aria-label="View post: ${post.title || "Untitled Post"}"
-       >
-        ${
-          media
-            ? `<img
-                class="post-card__image"
-                src="${media}"
-                alt="${alt}"
-                fetchpriority="high"
-              >`
-            : ""
-        }
+ return `
+  <article class="post-card">
+    <a
+      class="post-card__media-link"
+      href="${ROUTES.post(post.id)}"
+      aria-label="View post: ${post.title || "Untitled Post"}"
+    >
+      ${
+        media
+          ? `<img
+              class="post-card__image"
+              src="${media}"
+              alt="${alt}"
+              fetchpriority="high"
+            >`
+          : ""
+      }
+    </a>
+
+    <div class="post-card__content">
+      <a class="post-card__content-link" href="${ROUTES.post(post.id)}">
+        <h2 class="post-card__title">${post.title || "Untitled Post"}</h2>
+        <p class="post-card__body">${trimmedBody}</p>
       </a>
 
-      <div class="post-card__content">
-        <a class="post-card__content-link" href="${ROUTES.post(post.id)}">
-          <h2 class="post-card__title">${post.title || "Untitled Post"}</h2>
-          <p class="post-card__body">${trimmedBody}</p>
+      <div class="post-card__meta">
+        <a
+          class="post-card__author"
+          href="${ROUTES.profile(author)}"
+        >
+          By ${author}
         </a>
 
-        <div class="post-card__meta">
-          <a 
-            class="post-card__author" 
-            href="${ROUTES.profile(author)}"
-         >
-            By ${author}
-         </a>
-          ${
-            !isOwner && actionMarkup
-             ? `<div class="post-card__actions">${actionMarkup}</div>` : ""}
-        </div>
+        ${
+          !isOwner && actionMarkup
+            ? `<div class="post-card__actions">${actionMarkup}</div>`
+            : ""
+        }
       </div>
-    </article>
-  `;
+
+      <a class="post-card__comments" href="${ROUTES.post(post.id)}">
+        Comments (${commentCount})
+      </a>
+    </div>
+  </article>
+`;
 }

--- a/js/pages/post.js
+++ b/js/pages/post.js
@@ -3,6 +3,8 @@ import { getPostById, deletePost } from "../api/posts.js";
 import { getProfile } from "../storage/profile.js";
 import { getToken } from "../storage/token.js";
 import { createButton } from "../components/button.js";
+import { renderComments } from "../components/comments.js";
+import { createComment } from "../api/comments.js";
 
 const root = document.getElementById("app");
 
@@ -23,6 +25,36 @@ function getPostIdFromUrl() {
  * @async
  * @returns {Promise<void>}
  */
+function attachCommentForm(postId) {
+  const form = root.querySelector("#comment-form");
+  const textarea = root.querySelector("#comment-body");
+  const message = root.querySelector("#comment-message");
+
+  if (!form || !textarea || !message) return;
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const body = textarea.value.trim();
+
+    if (!body) {
+      message.textContent = "Comment cannot be empty.";
+      return;
+    }
+
+    message.textContent = "Posting comment...";
+
+    try {
+      await createComment(postId, body);
+      textarea.value = "";
+      message.textContent = "Comment posted.";
+      await renderPost();
+    } catch (error) {
+      console.error("Failed to create comment:", error);
+      message.textContent = "Unable to post comment right now. Please try again.";
+    }
+  });
+}
 async function renderPost() {
   const token = getToken();
 
@@ -58,6 +90,8 @@ async function renderPost() {
       return;
     }
 
+    const comments = post.comments || [];
+
     const profile = getProfile();
     const currentUserName = profile?.name?.trim().toLowerCase();
     const ownerName = post.author?.name?.trim().toLowerCase();
@@ -88,7 +122,9 @@ async function renderPost() {
             : ""
         }
       </article>
+      ${renderComments(comments)}
     `;
+    attachCommentForm(post.id);
 
     if (isOwner) {
       const actionsContainer = document.querySelector(".post__actions");


### PR DESCRIPTION
- Implement createComment API endpoint
- Add reusable comments component with render + form handling
- Enable posting comments on single post page
- Display comments list with empty state handling
- Include comment count (_count.comments) in feed posts
- Refactor post card layout to support comment metadata without breaking UI