### PR TITLE
fix: reactions on post and feed changed

### DIFF
--- a/js/api/posts.js
+++ b/js/api/posts.js
@@ -7,6 +7,7 @@ export function getPosts({ limit = 12, sort = "created", sortOrder = "desc" } = 
     sortOrder,
     _author: "true",
     _count: "true",
+    _reactions: "true",
   });
 
   return apiRequest(`/social/posts?${params.toString()}`);

--- a/js/api/reactions.js
+++ b/js/api/reactions.js
@@ -12,13 +12,18 @@ export async function reactToPost(postId, symbol) {
   if (!token) throw new Error("Missing auth token");
   if (!apiKey) throw new Error("Missing API key");
 
-  const response = await fetch(`${CONFIG.BASE_URL}/social/posts/${postId}/react/${symbol}`, {
-    method: "PUT",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "X-Noroff-API-Key": apiKey,
-    },
-  });
+  const encodedSymbol = encodeURIComponent(symbol);
+
+  const response = await fetch(
+    `${CONFIG.BASE_URL}/social/posts/${postId}/react/${encodedSymbol}`,
+    {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "X-Noroff-API-Key": apiKey,
+      },
+    }
+  );
 
   const data = await response.json().catch(() => null);
 

--- a/js/components/postCard.js
+++ b/js/components/postCard.js
@@ -14,6 +14,7 @@ import { ROUTES } from "../config/routes.js";
 export function createPostCard(post, options = {}) {
   const {
     actionMarkup = "",
+    reactionMarkup = "",
     currentUserName = "",
   } = options;
 
@@ -70,6 +71,12 @@ export function createPostCard(post, options = {}) {
             : ""
         }
       </div>
+
+            ${
+        reactionMarkup
+          ? `<div class="post-card__reactions">${reactionMarkup}</div>`
+          : ""
+      }
 
       <a class="post-card__comments" href="${ROUTES.post(post.id)}">
         Comments (${commentCount})

--- a/js/pages/feed.js
+++ b/js/pages/feed.js
@@ -9,6 +9,7 @@ import { getToken } from "../storage/token.js";
 import { getProfile } from "../storage/profile.js";
 import { BASE_PATH } from "../api/config.js";
 import { ROUTES } from "../config/routes.js";
+import { reactToPost } from "../api/reactions.js";
 
 const root = document.getElementById("app");
 let allPosts = [];
@@ -87,15 +88,35 @@ function createFollowButtonMarkup(authorName, isFollowing) {
  * @param {object} followState - The current user's follow state.
  * @returns {string} HTML string for a single feed post card.
  */
+
+function getReactionCount(reactions = [], symbol = "👍") {
+  const match = reactions.find((reaction) => reaction.symbol === symbol);
+  return match?.count ?? 0;
+}
+
 function createFeedCardMarkup(post, followState) {
   const authorName = post.author?.name?.trim() || "";
   const normalizedAuthorName = authorName.toLowerCase();
   const isFollowing = followState.followingNames.has(normalizedAuthorName);
 
   const actionMarkup = createFollowButtonMarkup(authorName, isFollowing);
+  const reactionCount = getReactionCount(post.reactions, "👍");
+
+  const reactionMarkup = `
+    <button
+      type="button"
+      class="post-card__reaction-btn"
+      data-react-post="${post.id}"
+      data-reaction-symbol="👍"
+      aria-label="Toggle thumbs up reaction"
+    >
+      👍 <span class="post-card__reaction-count">${reactionCount}</span>
+    </button>
+  `;
 
   return createPostCard(post, {
     actionMarkup,
+    reactionMarkup,
     currentUserName: followState.currentUserName,
   });
 }
@@ -293,7 +314,27 @@ function attachFeedEvents(followState) {
 
       return;
     }
+    
+   const reactionButton = event.target.closest("[data-react-post]");
+   if (reactionButton) {
+      const postId = reactionButton.dataset.reactPost;
+      const symbol = reactionButton.dataset.reactionSymbol;
 
+      if (!postId || !symbol) return;
+
+      reactionButton.disabled = true;
+
+      try {
+        await reactToPost(postId, symbol);
+        await renderFeed();
+      } catch (error) {
+        console.error("Failed to update reaction:", error);
+        reactionButton.disabled = false;
+        window.alert("Unable to update reaction right now. Please try again.");
+      }
+
+      return;
+    }
     const button = event.target.closest("[data-follow-author]");
     if (!button) return;
 
@@ -390,6 +431,8 @@ async function renderFeed() {
 
         <input
           type="search"
+          id="feed-search"
+          name="feed-search"
           class="feed-search"
           placeholder="Search posts..."
           aria-label="Search posts"

--- a/js/pages/post.js
+++ b/js/pages/post.js
@@ -8,7 +8,7 @@ import { createComment } from "../api/comments.js";
 import { reactToPost } from "../api/reactions.js";
 
 const root = document.getElementById("app");
-const REACTIONS = ["👍", "❤️", "😂", "🔥"];
+const REACTIONS = ["👍",];
 
 /**
  * Reads the post ID from the current page URL query string.
@@ -112,20 +112,16 @@ function attachReactionEvents(postId) {
   reactionButtons.forEach((button) => {
     button.addEventListener("click", async () => {
       const symbol = button.dataset.reaction;
-
       if (!symbol) return;
+
+      reactionButtons.forEach((btn) => {
+        btn.disabled = true;
+      });
 
       try {
         button.disabled = true;
-        const result = await reactToPost(postId, symbol);
-
-       const updatedReaction = result.data.reactions.find(r => r.symbol === symbol);
-       const newCount = updatedReaction?.count ?? 0;
-
-       const countEl = button.querySelector(".post-reactions__count");
-       if (countEl) {
-           countEl.textContent = newCount;
-    }  
+        await reactToPost(postId, symbol);
+        await renderPost();
       } catch (error) {
         console.error("Failed to update reaction:", error);
         window.alert("Unable to update reaction right now. Please try again.");


### PR DESCRIPTION
Changed to use only one reaction on posts.
API seem to support only  👍 for toggle on and off, 
the other reactions will act as each their own switch, making
the reaction field confusing to users